### PR TITLE
Add debug statement to provider when trigger is invoked

### DIFF
--- a/provider/lib/utils.js
+++ b/provider/lib/utils.js
@@ -98,6 +98,9 @@ module.exports = function(
         var method = 'postTrigger';
 
         return new Promise(function(resolve, reject) {
+            var triggerIdentifier = utils.getTriggerIdentifier(dataTrigger.apikey, dataTrigger.namespace, dataTrigger.name);
+
+            logger.info(method, triggerIdentifier, "http post request against OpenWhisk sent");
 
             request({
                 method: 'post',
@@ -109,7 +112,6 @@ module.exports = function(
                 json: payload
             }, function(error, response) {
                 try {
-                    var triggerIdentifier = utils.getTriggerIdentifier(dataTrigger.apikey, dataTrigger.namespace, dataTrigger.name);
                     logger.info(method, triggerIdentifier, 'http post request, STATUS:', response ? response.statusCode : response);
 
                     if (error || response.statusCode >= 400) {


### PR DESCRIPTION
We have a suspicion, that a trigger could be invoked to often, if the request to OpenWhisk takes longer than the time between the last two triggers.
With this PR we add some additional logging, to validate this theory and to enhance the logging of the provider.

Current logs of a trigger that has been invoked too often:
```
[2017-05-30T13:47:06.428Z] [INFO] [??] [alarmsTrigger] [POST /triggers] Got trigger {"name":"dummyAlarmsTrigger-1496152025010","namespace":"[NAMESPACE]","cron":"* * * * * *","payload":{"payload":"alarmTest"},"maxTriggers":3}
[2017-05-30T13:47:06.428Z] [INFO] [??] [alarmsTrigger] [POST /triggers] Checking if user has access rights to create a trigger
[2017-05-30T13:47:06.442Z] [INFO] [??] [alarmsTrigger] [createTrigger] [UUID:KEY]/[NAMESPACE]/dummyAlarmsTrigger-1496152025010 starting cron job
[2017-05-30T13:47:06.746Z] [INFO] [??] [alarmsTrigger] [POST /triggers] [UUID:KEY]/[NAMESPACE]/dummyAlarmsTrigger-1496152025010 created successfully
[2017-05-30T13:47:08.577Z] [INFO] [??] [alarmsTrigger] [postTrigger] [UUID:KEY]/[NAMESPACE]/dummyAlarmsTrigger-1496152025010 http post request, STATUS: 200
[2017-05-30T13:47:08.578Z] [INFO] [??] [alarmsTrigger] [postTrigger] fired [UUID:KEY]/[NAMESPACE]/dummyAlarmsTrigger-1496152025010 2 triggers left
[2017-05-30T13:47:08.579Z] [INFO] [??] [alarmsTrigger] [fireTrigger] Trigger [UUID:KEY]/[NAMESPACE]/dummyAlarmsTrigger-1496152025010 was successfully fired
[2017-05-30T13:47:09.625Z] [INFO] [??] [alarmsTrigger] [postTrigger] [UUID:KEY]/[NAMESPACE]/dummyAlarmsTrigger-1496152025010 http post request, STATUS: 200
[2017-05-30T13:47:09.625Z] [INFO] [??] [alarmsTrigger] [postTrigger] fired [UUID:KEY]/[NAMESPACE]/dummyAlarmsTrigger-1496152025010 1 triggers left
[2017-05-30T13:47:09.626Z] [INFO] [??] [alarmsTrigger] [fireTrigger] Trigger [UUID:KEY]/[NAMESPACE]/dummyAlarmsTrigger-1496152025010 was successfully fired
[2017-05-30T13:47:10.578Z] [INFO] [??] [alarmsTrigger] [postTrigger] [UUID:KEY]/[NAMESPACE]/dummyAlarmsTrigger-1496152025010 http post request, STATUS: 200
[2017-05-30T13:47:10.578Z] [INFO] [??] [alarmsTrigger] [postTrigger] fired [UUID:KEY]/[NAMESPACE]/dummyAlarmsTrigger-1496152025010 0 triggers left
[2017-05-30T13:47:10.580Z] [INFO] [??] [alarmsTrigger] [fireTrigger] Trigger [UUID:KEY]/[NAMESPACE]/dummyAlarmsTrigger-1496152025010 was successfully fired
[2017-05-30T13:47:10.581Z] [INFO] [??] [alarmsTrigger] [disableTrigger] trigger [UUID:KEY]/[NAMESPACE]/dummyAlarmsTrigger-1496152025010 successfully disabled
[2017-05-30T13:47:10.584Z] [ERROR] [??] [alarmsTrigger] [fireTrigger] no more triggers left, disabled [UUID:KEY]/[NAMESPACE]/dummyAlarmsTrigger-1496152025010
[2017-05-30T13:47:11.212Z] [INFO] [??] [alarmsTrigger] [disableTriggerInDB] trigger [UUID:KEY]/[NAMESPACE]/dummyAlarmsTrigger-1496152025010 successfully disabled in database
[2017-05-30T13:47:12.574Z] [INFO] [??] [alarmsTrigger] [postTrigger] [UUID:KEY]/[NAMESPACE]/dummyAlarmsTrigger-1496152025010 http post request, STATUS: 200
[2017-05-30T13:47:12.575Z] [INFO] [??] [alarmsTrigger] [postTrigger] fired [UUID:KEY]/[NAMESPACE]/dummyAlarmsTrigger-1496152025010 -1 triggers left
[2017-05-30T13:47:12.575Z] [INFO] [??] [alarmsTrigger] [fireTrigger] Trigger [UUID:KEY]/[NAMESPACE]/dummyAlarmsTrigger-1496152025010 was successfully fired
[2017-05-30T13:47:15.371Z] [INFO] [??] [alarmsTrigger] [deleteTriggerFromDB] trigger [UUID:KEY]/[NAMESPACE]/dummyAlarmsTrigger-1496152025010 successfully deleted
```

Signed-off-by: Vadim Raskin <vadimr@de.ibm.com>