### PR TITLE
Continue initialization if redundant provider is creating the filter

### DIFF
--- a/provider/app.js
+++ b/provider/app.js
@@ -51,7 +51,7 @@ function createDatabase(nanop) {
             if (!err) {
                 logger.info(method, 'created trigger database:', databaseName);
             }
-            else {
+            else if (err.statusCode !== 412) {
                 logger.info(method, 'failed to create trigger database:', databaseName, err);
             }
             var db = nanop.db.use(databaseName);
@@ -68,7 +68,7 @@ function createDatabase(nanop) {
                             only_triggers_by_worker: only_triggers_by_worker
                         },
                     }, ddname, function (error, body) {
-                        if (error) {
+                        if (error && error.statusCode !== 409) {
                             reject("filter could not be created: " + error);
                         }
                         resolve(db);


### PR DESCRIPTION
A document update conflict (409) on filter creation is only possible if a redundant provider is currently creating the filter.  Do not exit provider initialization in this situation.  Also do not display message stating database creation failed if database already exists (412)