### PR TITLE
Avoid that trigger is fired too often if Request to OpenWhisk is too …

### DIFF
--- a/provider/lib/utils.js
+++ b/provider/lib/utils.js
@@ -99,6 +99,11 @@ module.exports = function(
 
         return new Promise(function(resolve, reject) {
 
+            // only manage trigger fires if they are not infinite
+            if (dataTrigger.maxTriggers !== -1) {
+                dataTrigger.triggersLeft--;
+            }
+
             request({
                 method: 'post',
                 uri: uri,
@@ -113,6 +118,10 @@ module.exports = function(
                     logger.info(method, triggerIdentifier, 'http post request, STATUS:', response ? response.statusCode : response);
 
                     if (error || response.statusCode >= 400) {
+                        // only manage trigger fires if they are not infinite
+                        if (dataTrigger.maxTriggers !== -1) {
+                            dataTrigger.triggersLeft++;
+                        }
                         logger.error(method, 'there was an error invoking', triggerIdentifier, response ? response.statusCode : error);
                         if (!error && utils.shouldDisableTrigger(response.statusCode)) {
                             //disable trigger
@@ -136,10 +145,6 @@ module.exports = function(
                             }
                         }
                     } else {
-                        // only manage trigger fires if they are not infinite
-                        if (dataTrigger.maxTriggers !== -1) {
-                            dataTrigger.triggersLeft--;
-                        }
                         logger.info(method, 'fired', triggerIdentifier, dataTrigger.triggersLeft, 'triggers left');
                         resolve(triggerIdentifier);
                     }


### PR DESCRIPTION
…slow.

If a trigger which should fire in an interval of 1 second is created, and the request to the core of OpenWhisk takes longer than 1 second, this trigger will be fired more often then it is supposed to be.