### PR TITLE
add parameters as query parameters for get request

### DIFF
--- a/action/lib/common.js
+++ b/action/lib/common.js
@@ -4,12 +4,20 @@ function requestHelper(url, input, method) {
 
     return new Promise(function(resolve, reject) {
 
-        request({
+        var options = {
             method : method,
             url : url,
-            json: input,
+            json: true,
             rejectUnauthorized: false
-        }, function(error, response, body) {
+        };
+
+        if (method === 'get') {
+            options.qs = input;
+        } else {
+            options.body = input;
+        }
+
+        request(options, function(error, response, body) {
 
             if (!error && response.statusCode === 200) {
                 resolve(body);


### PR DESCRIPTION
fix for `trigger get` failing in production because of executing a get request with a body