### PR TITLE
Add interval support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ The package includes the following feeds.
 | `/whisk.system/alarms` | package | - | Alarms and periodic utility |
 | `/whisk.system/alarms/alarm` | feed | cron, trigger_payload, maxTriggers, startDate, stopDate | Fire trigger event periodically |
 | `/whisk.system/alarms/once` | feed | date, trigger_payload | Fire trigger event once on a specific date |
+| `/whisk.system/alarms/interval` | feed | minutes, trigger_payload, startDate, stopDate | Fire trigger event on an interval based schedule |
 
 
-## Firing a trigger event periodically
+## Firing a trigger event periodically on a time based schedule
 
 The `/whisk.system/alarms/alarm` feed configures the Alarm service to fire a trigger event at a specified frequency. The parameters are as follows:
 
@@ -56,6 +57,35 @@ January 1, 2019, 00:00:00 UTC and will stop firing January 31, 2019, 23:59:00 UT
   ```
 
 Each generated event will include as parameters the properties specified in the `trigger_payload` value. In this case, each trigger event will have parameters `name=Odin` and `place=Asgard`.
+
+
+## Firing a trigger event periodically on an interval based schedule
+
+The `/whisk.system/alarms/interval` feed configures the Alarm service to fire a trigger event on an interval based schedule. The parameters are as follows:
+
+- `minutes`: An integer representing the length of the interval (in minutes) between trigger fires.
+
+- `trigger_payload`: The value of this parameter becomes the content of the trigger every time the trigger is fired.
+
+- `startDate`: The date when the first trigger will be fired.  Subsequent fires will occur based on the interval length specified by the `minutes` parameter.   
+
+- `stopDate`: The date when the trigger will stop running.  Triggers will no longer be fired once this date has been reached.
+
+  **Note**: The `startDate` and `stopDate` parameters support an integer or string value.  The integer value represents the number of milliseconds 
+  since 1 January 1970 00:00:00 UTC and the string value should be in the ISO 8601 format (http://www.ecma-international.org/ecma-262/5.1/#sec-15.9.1.15).
+
+
+The following is an example of creating a trigger that will be fired once every 90 minutes.  The trigger will not start firing until
+January 1, 2019, 00:00:00 UTC and will stop firing January 31, 2019, 23:59:00 UTC.
+
+  ```
+  wsk trigger create interval \
+    --feed /whisk.system/alarms/interval \
+    --param minutes 90 \
+    --param trigger_payload "{\"name\":\"Odin\",\"place\":\"Asgard\"}" \
+    --param startDate "2019-01-01T00:00:00.000Z" \
+    --param stopDate "2019-01-31T23:59:00.000Z"
+  ```
 
 ## Firing a trigger event once  
 

--- a/action/alarmWebAction.js
+++ b/action/alarmWebAction.js
@@ -106,17 +106,9 @@ function main(params) {
                 }
                 newTrigger.stopDate = stopDate;
 
-                //verify that the next scheduled trigger fire will occur before the stop date
-                var nextTriggerDate;
-                if (cronHandle) {
-                    nextTriggerDate = cronHandle.nextDate();
-                }
-                else {
-                    var momentStartDate = moment(new Date(newTrigger.startDate));
-                    nextTriggerDate = momentStartDate.add(params.minutes, 'minutes');
-                }
-                if (nextTriggerDate.isAfter(new Date(params.stopDate))) {
-                    return common.sendError(400, 'the next scheduled trigger fire is not until after the stop date');
+                //verify that the first scheduled trigger fire will occur before the stop date
+                if (cronHandle && cronHandle.nextDate().isAfter(new Date(params.stopDate))) {
+                    return common.sendError(400, 'the first scheduled trigger fire is not until after the stop date');
                 }
             }
         }

--- a/action/alarmWebAction.js
+++ b/action/alarmWebAction.js
@@ -49,16 +49,33 @@ function main(params) {
             newTrigger.date = date;
         }
         else {
-            if (!params.cron) {
-                return common.sendError(400, 'alarms trigger feed is missing the cron parameter');
-            }
-
             var cronHandle;
-            try {
-                cronHandle = new CronJob(params.cron, function() {});
-                newTrigger.cron = params.cron;
-            } catch(ex) {
-                return common.sendError(400, `cron pattern '${params.cron}' is not valid`);
+
+            if (params.isInterval) {
+                if (!params.minutes) {
+                    return common.sendError(400, 'interval trigger feed is missing the minutes parameter');
+                }
+                if (+params.minutes !== parseInt(params.minutes)) {
+                    return common.sendError(400, 'the minutes parameter must be an integer');
+                }
+                var minutesParam = parseInt(params.minutes);
+
+                if (minutesParam <= 0) {
+                    return common.sendError(400, 'the minutes parameter must be an integer greater than zero');
+                }
+                newTrigger.minutes = minutesParam;
+            }
+            else {
+                if (!params.cron) {
+                    return common.sendError(400, 'alarms trigger feed is missing the cron parameter');
+                }
+
+                try {
+                    cronHandle = new CronJob(params.cron, function() {});
+                    newTrigger.cron = params.cron;
+                } catch(ex) {
+                    return common.sendError(400, `cron pattern '${params.cron}' is not valid`);
+                }
             }
 
             if (params.startDate) {
@@ -68,23 +85,39 @@ function main(params) {
                 }
                 newTrigger.startDate = startDate;
             }
+            else if (params.isInterval) {
+                //if startDate was not given we will start it 30 seconds
+                //from now since startDate must be in the future
+                newTrigger.startDate = Date.now() + (1000 * 30);
+            }
 
-            if (params.stopDate) {
-                if (params.maxTriggers) {
+            if (params.maxTriggers && params.stopDate) {
+                if (params.isInterval) {
+                    return common.sendError(400, 'maxTriggers is not supported for the interval trigger feed');
+                }
+                else {
                     return common.sendError(400, 'maxTriggers is not allowed when the stopDate parameter is specified');
                 }
-
-                var stopDate = validateDate(params.stopDate, 'stopDate', params.startDate);
+            }
+            else if (params.stopDate) {
+                var stopDate = validateDate(params.stopDate, 'stopDate', newTrigger.startDate);
                 if (stopDate !== params.stopDate) {
                     return common.sendError(400, stopDate);
                 }
+                newTrigger.stopDate = stopDate;
+
                 //verify that the next scheduled trigger fire will occur before the stop date
-                var triggerDate = cronHandle.nextDate();
-                if (triggerDate.isAfter(new Date(params.stopDate))) {
+                var nextTriggerDate;
+                if (cronHandle) {
+                    nextTriggerDate = cronHandle.nextDate();
+                }
+                else {
+                    var momentStartDate = moment(new Date(newTrigger.startDate));
+                    nextTriggerDate = momentStartDate.add(params.minutes, 'minutes');
+                }
+                if (nextTriggerDate.isAfter(new Date(params.stopDate))) {
                     return common.sendError(400, 'the next scheduled trigger fire is not until after the stop date');
                 }
-
-                newTrigger.stopDate = stopDate;
             }
         }
 
@@ -137,9 +170,14 @@ function main(params) {
                     body.config.date = doc.date;
                 }
                 else {
-                    body.config.cron = doc.cron;
                     body.config.startDate = doc.startDate;
                     body.config.stopDate = doc.stopDate;
+                    if (doc.minutes) {
+                        body.config.minutes = doc.minutes;
+                    }
+                    else {
+                        body.config.cron = doc.cron;
+                    }
                 }
                 resolve({
                     statusCode: 200,
@@ -158,7 +196,7 @@ function main(params) {
             common.verifyTriggerAuth(triggerURL, params.authKey, true)
             .then(() => {
                 db = new Database(params.DB_URL, params.DB_NAME);
-                return db.updateTrigger(triggerID, 0);
+                return db.disableTrigger(triggerID, 0);
             })
             .then(id => {
                 return db.deleteTrigger(id, 0);

--- a/action/lib/Database.js
+++ b/action/lib/Database.js
@@ -85,7 +85,7 @@ module.exports = function(dbURL, dbName) {
         });
     };
 
-    this.updateTrigger = function(triggerID, retryCount) {
+    this.disableTrigger = function(triggerID, retryCount) {
 
         return new Promise(function(resolve, reject) {
 
@@ -98,7 +98,7 @@ module.exports = function(dbURL, dbName) {
                         if (err) {
                             if (err.statusCode === 409 && retryCount < 5) {
                                 setTimeout(function () {
-                                    utilsDB.updateTrigger(triggerID, (retryCount + 1))
+                                    utilsDB.disableTrigger(triggerID, (retryCount + 1))
                                     .then(id => {
                                         resolve(id);
                                     })
@@ -121,7 +121,7 @@ module.exports = function(dbURL, dbName) {
                     if (retryCount === 0) {
                         var parts = triggerID.split('/');
                         var id = parts[0] + '/_/' + parts[2];
-                        utilsDB.updateTrigger(id, (retryCount + 1))
+                        utilsDB.disableTrigger(id, (retryCount + 1))
                         .then(id => {
                             resolve(id);
                         })

--- a/installCatalog.sh
+++ b/installCatalog.sh
@@ -76,6 +76,12 @@ $WSK_CLI -i --apihost "$EDGEHOST" action update --kind nodejs:6 --auth "$AUTH" a
      -a feed true \
      -p fireOnce true
 
+$WSK_CLI -i --apihost "$EDGEHOST" action update --kind nodejs:6 --auth "$AUTH" alarms/interval "$PACKAGE_HOME/action/alarmFeed.zip" \
+     -a description 'Fire trigger at specified interval' \
+     -a parameters '[ {"name":"minutes", "required":true}, {"name":"startDate", "required":false}, {"name":"stopDate", "required":false} ]' \
+     -a feed true \
+     -p isInterval true
+
 if [ -n "$WORKERS" ];
 then
     $WSK_CLI -i --apihost "$EDGEHOST" package update --auth "$AUTH" --shared no alarmsWeb \

--- a/provider/lib/cronAlarm.js
+++ b/provider/lib/cronAlarm.js
@@ -10,6 +10,7 @@ module.exports = function(logger, newTrigger) {
         apikey: newTrigger.apikey,
         name: newTrigger.name,
         namespace: newTrigger.namespace,
+        payload: newTrigger.payload,
         cron: newTrigger.cron
     };
 

--- a/provider/lib/dateAlarm.js
+++ b/provider/lib/dateAlarm.js
@@ -6,6 +6,7 @@ module.exports = function(logger, newTrigger) {
         apikey: newTrigger.apikey,
         name: newTrigger.name,
         namespace: newTrigger.namespace,
+        payload: newTrigger.payload,
         date: newTrigger.date
     };
 

--- a/provider/lib/intervalAlarm.js
+++ b/provider/lib/intervalAlarm.js
@@ -1,0 +1,66 @@
+var lt =  require('long-timeout');
+
+module.exports = function(logger, newTrigger) {
+
+
+    var cachedTrigger = {
+        apikey: newTrigger.apikey,
+        name: newTrigger.name,
+        namespace: newTrigger.namespace,
+        payload: newTrigger.payload,
+        minutes: newTrigger.minutes
+    };
+
+    this.scheduleAlarm = function(triggerIdentifier, callback) {
+        var method = 'scheduleIntervalAlarm';
+
+        try {
+            return new Promise(function(resolve, reject) {
+
+                var intervalInMilliSeconds = newTrigger.minutes * 1000 * 60;
+                var startDate = new Date(newTrigger.startDate).getTime();
+
+                if (newTrigger.stopDate) {
+                    cachedTrigger.stopDate = newTrigger.stopDate;
+                    //do not create trigger if the stopDate is in the past
+                    if (new Date(newTrigger.stopDate).getTime() <= Date.now()) {
+                        return reject('the stop date has expired');
+                    }
+                }
+
+                if (startDate > Date.now()) {
+                    //fire the trigger and start the interval on the start date
+                    logger.info(method, triggerIdentifier, 'waiting for start date', startDate);
+                    lt.setTimeout(function() {
+                        logger.info(method, triggerIdentifier, 'firing first trigger and starting interval upon reaching start date', startDate);
+                        var intervalHandle = lt.setInterval(callback, intervalInMilliSeconds);
+                        cachedTrigger.intervalHandle = intervalHandle;
+                        resolve(cachedTrigger);
+                    }, startDate - Date.now());
+                }
+                else {
+                    //fire the trigger and start the interval at the next scheduled interval
+                    //as long as the next scheduled interval is not past the stop date
+                    var intervalsFired = Math.floor((Date.now() - startDate)/intervalInMilliSeconds);
+                    var nextScheduledInterval = startDate + (intervalInMilliSeconds * (intervalsFired + 1));
+
+                    if (newTrigger.stopDate && nextScheduledInterval > new Date(newTrigger.stopDate).getTime()) {
+                        return reject('the next scheduled trigger fire is after the stop date');
+                    }
+
+                    logger.info(method, triggerIdentifier, 'waiting for next interval');
+                    lt.setTimeout(function() {
+                        logger.info(method, triggerIdentifier, 'firing trigger and starting interval for trigger past its start date');
+                        var intervalHandle = lt.setInterval(callback, intervalInMilliSeconds);
+                        cachedTrigger.intervalHandle = intervalHandle;
+                        resolve(cachedTrigger);
+                    }, nextScheduledInterval - Date.now());
+                }
+
+            });
+        } catch (err) {
+            return Promise.reject(err);
+        }
+    };
+
+};

--- a/tests/src/test/scala/system/packages/AlarmsFeedWebTests.scala
+++ b/tests/src/test/scala/system/packages/AlarmsFeedWebTests.scala
@@ -51,25 +51,25 @@ class AlarmsFeedWebTests
         wsk.action.get(webAction, FORBIDDEN)
     }
 
-    it should "reject put of a trigger due to missing triggerName argument" in {
+    it should "reject post of a trigger due to missing triggerName argument" in {
         val params = JsObject(originalParams.fields - "triggerName")
 
         makePostCallWithExpectedResult(params, JsObject("error" -> JsString("no trigger name parameter was provided")), 400)
     }
 
-    it should "reject put of a trigger due to missing cron argument" in {
+    it should "reject post of a trigger due to missing cron argument" in {
         val params = JsObject(originalParams.fields - "cron")
 
         makePostCallWithExpectedResult(params, JsObject("error" -> JsString("alarms trigger feed is missing the cron parameter")), 400)
     }
 
-    it should "reject put of a trigger due to invalid cron argument" in {
+    it should "reject post of a trigger due to invalid cron argument" in {
         val params = JsObject(originalParams.fields + ("cron" -> JsString("***")))
 
         makePostCallWithExpectedResult(params, JsObject("error" -> JsString("cron pattern '***' is not valid")), 400)
     }
 
-    it should "reject put of a trigger when authentication fails" in {
+    it should "reject post of a trigger when authentication fails" in {
         val params = JsObject(originalParams.fields + ("cron" -> JsString("* * * * *")))
         makePostCallWithExpectedResult(params, JsObject("error" -> JsString("Trigger authentication request failed.")), 401)
     }


### PR DESCRIPTION
Today the cron syntax doesn't allow to specify intervals, only at the hour mark, and then repeat on the next hour. User have requests that they want more control over the internal of the fires for example every 16, or 12 minutes.
Example configuration

wsk trigger create interval \ 
--feed /whisk.system/alarms/interval \
--param minutes 16 \
--param startDate “2017-10-27T14:02”
--param stopDate “2017-10-28T14:00”