### PR TITLE
URL parsing problem in database connection

### DIFF
--- a/provider/app.js
+++ b/provider/app.js
@@ -46,7 +46,12 @@ function createDatabase() {
     var method = 'createDatabase';
     logger.info(method, 'creating the trigger database');
 
-    var nano = require('nano')(dbProtocol + '://' + dbUsername + ':' + dbPassword + '@' + dbHost);
+    var nano = require('nano')({
+        url: dbProtocol + "://" + dbHost,
+        requestDefaults: {
+            auth: {user: dbUsername, pass: dbPassword}
+        }
+    });
 
     if (nano !== null) {
         return new Promise(function (resolve, reject) {


### PR DESCRIPTION
When I deploying this project, there was a problem. Passwords with `@` do not create to the database. 

There is error logs
```
[2017-12-06T09:24:01.614Z] [INFO] [??] [alarmsTrigger] [createDatabase] creating the trigger database
/alarmsTrigger/node_modules/nano/lib/nano.js:55
    var pathArray = path.pathname.split('/').filter(function(e) { return e; });
                                 ^

TypeError: Cannot read property 'split' of null
    at maybeExtractDatabaseComponent (/alarmsTrigger/node_modules/nano/lib/nano.js:55:34)
    at dbScope (/alarmsTrigger/node_modules/nano/lib/nano.js:864:12)
    at createDatabase (/alarmsTrigger/app.js:49:31)
    at init (/alarmsTrigger/app.js:165:5)
    at Object.<anonymous> (/alarmsTrigger/app.js:196:1)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
    at run (bootstrap_node.js:383:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:496:3
```

Caused by `nano.js`
```js
var u = require("url")
....
var path = u.parse(cfg.url); //  Parsing does not work!
var pathArray = path.pathname.split('/').filter(function(e) { return e; }); // Error!
```

## For example - Error case

### Input
db_protocol = `http`
db_username = `test`
db_password = `test!@test`
db_host = `db.naver.com:5984`
```
http://test:test!@test@db.naver.com:5984
```

### Output
```
Url {
  protocol: 'http:',
  slashes: true,
  auth: 'test:test!',
  host: '',
  port: null,
  hostname: '',
  hash: 'test@db.naver.com:5984',
  search: null,
  query: null,
  pathname: null,
  path: null,
  href: 'http://test@db.naver.com:5984' }
```

## In conclusion 
If `dbPassword` has `@`, Parsing do not work. So the following code can be problematic.
```js
var nano = require('nano')(dbProtocol + '://' + dbUsername + ':' + dbPassword + '@' + dbHost);
```
