### PR TITLE
change logs from file to standard out

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ ADD provider/. /alarmsTrigger/
 
 EXPOSE 8080
 
-CMD ["/bin/bash", "-c", "node /alarmsTrigger/app.js >> /logs/alarmsTrigger_logs.log 2>&1"]
+CMD ["/bin/bash", "-c", "node /alarmsTrigger/app.js"]


### PR DESCRIPTION
Close issue #93

This PR is to change alarm provider logging from file to standard out console. 
After applying this change, alarm provider log messages can be viewed by the standard docker command and kubectl command, i.e. `docker logs` and `kubectl logs`.