### PR TITLE
optionally limit cron fields to 5 instead of 6

### DIFF
--- a/action/alarmWebAction.js
+++ b/action/alarmWebAction.js
@@ -72,6 +72,10 @@ function main(params) {
 
                 try {
                     cronHandle = new CronJob(params.cron, function() {});
+                    //validate cron granularity if 5 fields are allowed instead of 6
+                    if (params.limitCronFields && hasSecondsGranularity(params.cron)) {
+                        return common.sendError(400, 'cron pattern is limited to 5 fields with 1 minute as the finest granularity');
+                    }
                     newTrigger.cron = params.cron;
                 } catch(ex) {
                     return common.sendError(400, `cron pattern '${params.cron}' is not valid`);
@@ -198,7 +202,7 @@ function main(params) {
                 }
 
                 if (params.trigger_payload) {
-                    updatedParams.payload = constructPayload(params.trigger_payload);
+                    updatedParams.payload = common.constructPayload(params.trigger_payload);
                 }
 
                 if (trigger.date) {
@@ -228,6 +232,10 @@ function main(params) {
                         if (params.cron) {
                             try {
                                 new CronJob(params.cron, function() {});
+                                //validate cron granularity if 5 fields are allowed instead of 6
+                                if (params.limitCronFields && hasSecondsGranularity(params.cron)) {
+                                    return common.sendError(400, 'cron pattern is limited to 5 fields with 1 minute as the finest granularity');
+                                }
                             } catch (ex) {
                                 return reject(common.sendError(400, `cron pattern '${params.cron}' is not valid`));
                             }
@@ -313,20 +321,6 @@ function main(params) {
     }
 }
 
-function constructPayload(payload) {
-
-    var updatedPayload;
-    if (payload) {
-        if (typeof payload === 'string') {
-            updatedPayload = {payload: payload};
-        }
-        if (typeof payload === 'object') {
-            updatedPayload = payload;
-        }
-    }
-    return updatedPayload;
-}
-
 function validateDate(date, paramName, startDate) {
 
     var dateObject = new Date(date);
@@ -344,6 +338,17 @@ function validateDate(date, paramName, startDate) {
         return date;
     }
 
+}
+
+function hasSecondsGranularity(cron) {
+
+    var fields = (cron + '').trim().split(/\s+/);
+
+    if (fields.length > 5 && fields[fields.length - 6] !== '0') {
+        return true;
+    }
+
+    return false;
 }
 
 exports.main = main;

--- a/action/lib/common.js
+++ b/action/lib/common.js
@@ -104,11 +104,26 @@ function sendError(statusCode, error, message) {
     };
 }
 
+function constructPayload(payload) {
+
+    var updatedPayload;
+    if (payload) {
+        if (typeof payload === 'string') {
+            updatedPayload = {payload: payload};
+        }
+        if (typeof payload === 'object') {
+            updatedPayload = payload;
+        }
+    }
+    return updatedPayload;
+}
+
 
 module.exports = {
     'requestHelper': requestHelper,
     'createWebParams': createWebParams,
     'verifyTriggerAuth': verifyTriggerAuth,
     'parseQName': parseQName,
-    'sendError': sendError
+    'sendError': sendError,
+    'constructPayload': constructPayload
 };

--- a/installCatalog.sh
+++ b/installCatalog.sh
@@ -12,9 +12,8 @@ set -x
 : ${OPENWHISK_HOME:?"OPENWHISK_HOME must be set and non-empty"}
 WSK_CLI="$OPENWHISK_HOME/bin/wsk"
 
-if [ $# -eq 0 ]
-then
-echo "Usage: ./installCatalog.sh <authkey> <edgehost> <dburl> <dbprefix> <apihost> <workers>"
+if [ $# -eq 0 ]; then
+    echo "Usage: ./installCatalog.sh <authkey> <edgehost> <dburl> <dbprefix> <apihost> <workers>"
 fi
 
 AUTH="$1"
@@ -23,6 +22,7 @@ DB_URL="$3"
 DB_NAME="${4}alarmservice"
 APIHOST="$5"
 WORKERS="$6"
+LIMIT_CRON_FIELDS="${LIMIT_CRON_FIELDS}"
 
 # If the auth key file exists, read the key in the file. Otherwise, take the
 # first argument as the key itself.
@@ -57,8 +57,7 @@ $WSK_CLI -i --apihost "$EDGEHOST" package update --auth "$AUTH" --shared yes ala
 # make alarmFeed.zip
 cd action
 
-if [ -e alarmFeed.zip ]
-then
+if [ -e alarmFeed.zip ]; then
     rm -rf alarmFeed.zip
 fi
 
@@ -82,26 +81,26 @@ $WSK_CLI -i --apihost "$EDGEHOST" action update --kind nodejs:6 --auth "$AUTH" a
      -a feed true \
      -p isInterval true
 
-if [ -n "$WORKERS" ];
-then
-    $WSK_CLI -i --apihost "$EDGEHOST" package update --auth "$AUTH" --shared no alarmsWeb \
-        -p DB_URL "$DB_URL" \
-        -p DB_NAME "$DB_NAME" \
-        -p apihost "$APIHOST" \
-        -p workers "$WORKERS"
-else
-    $WSK_CLI -i --apihost "$EDGEHOST" package update --auth "$AUTH" --shared no alarmsWeb \
-        -p DB_URL "$DB_URL" \
-        -p DB_NAME "$DB_NAME" \
-        -p apihost "$APIHOST"
+COMMAND=" -i --apihost $EDGEHOST package update --auth $AUTH --shared no alarmsWeb \
+    -p DB_URL $DB_URL \
+    -p DB_NAME $DB_NAME \
+    -p apihost $APIHOST"
+
+if [ -n "$WORKERS" ]; then
+    COMMAND+=" -p workers $WORKERS"
 fi
+
+if [ -n "$LIMIT_CRON_FIELDS" ]; then
+    COMMAND+=" -p limitCronFields $LIMIT_CRON_FIELDS"
+fi
+
+$WSK_CLI $COMMAND
 
 # make alarmWebAction.zip
 cp -f alarmWeb_package.json package.json
 npm install
 
-if [ -e alarmWebAction.zip ];
-then
+if [ -e alarmWebAction.zip ]; then
     rm -rf alarmWebAction.zip
 fi
 


### PR DESCRIPTION
This allows vendors to limit the finest granularity to 1 minute instead of 1 second.