### PR TITLE
Switch to Maven based dependency

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,14 +1,10 @@
-def owPath = System.getenv("OPENWHISK_HOME") ?: '../open'
-def owDirectory = new File(owPath)
-
-include 'common:scala'; project(':common:scala').projectDir = new File(owDirectory, 'common/scala')
-include 'core:controller'; project(':core:controller').projectDir = new File(owDirectory, 'core/controller')
-include 'core:invoker'; project(':core:invoker').projectDir = new File(owDirectory, 'core/invoker')
-include 'whisktests'; project(':whisktests').projectDir = new File(owDirectory, 'tests')
-
 include 'tests'
 
 rootProject.name = 'openwhisk-package-alarms'
+
+gradle.ext.openwhisk = [
+        version: '1.0.0-SNAPSHOT'
+]
 
 gradle.ext.scala = [
     version: '2.11.11',

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -2,10 +2,9 @@ apply plugin: 'scala'
 apply plugin: 'eclipse'
 compileTestScala.options.encoding = 'UTF-8'
 
-evaluationDependsOn(':whisktests')
-
 repositories {
     mavenCentral()
+    mavenLocal()
 }
 
 tasks.withType(Test) {
@@ -24,8 +23,8 @@ task testHealth(type: Test) {
 
 dependencies {
     compile "org.scala-lang:scala-library:${gradle.scala.version}"
-    compile project(':whisktests')
-    compile project(':whisktests').sourceSets.test.output
+    compile "org.apache.openwhisk:openwhisk-tests:${gradle.openwhisk.version}:tests"
+    compile "org.apache.openwhisk:openwhisk-tests:${gradle.openwhisk.version}:test-sources"
 }
 
 tasks.withType(ScalaCompile) {

--- a/tools/travis/setup.sh
+++ b/tools/travis/setup.sh
@@ -2,6 +2,7 @@
 
 SCRIPTDIR=$(cd $(dirname "$0") && pwd)
 HOMEDIR="$SCRIPTDIR/../../../"
+WHISKDIR="$HOMEDIR/openwhisk"
 
 sudo gpasswd -a travis docker
 sudo -E bash -c 'echo '\''DOCKER_OPTS="-H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock --api-enable-cors --storage-driver=aufs"'\'' > /etc/default/docker'
@@ -32,4 +33,11 @@ git clone https://github.com/apache/incubator-openwhisk-utilities.git
 
 # OpenWhisk stuff
 cd $HOMEDIR
-git clone https://github.com/openwhisk/openwhisk.git
+git clone https://github.com/apache/incubator-openwhisk.git openwhisk
+cd $WHISKDIR
+
+TERM=dumb ./gradlew \
+:common:scala:install \
+:core:controller:install \
+:core:invoker:install \
+:tests:install


### PR DESCRIPTION
This is required for apache/incubator-openwhisk#3277

In this project I did not find any gradle based test run. Still I have added travis task to build OpenWhisk locally. Let me know if that needs to be removed