### PR TITLE
Add a membership management using the discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "redis":"^2.7.1",
     "bluebird": "^3.5.0",
     "systeminformation": "^3.19.0",
-    "long-timeout": "^0.1.1"
+    "long-timeout": "^0.1.1",
+    "node-discover": "^0.6.2"
   }
 }

--- a/provider/lib/utils.js
+++ b/provider/lib/utils.js
@@ -7,7 +7,7 @@ var CronAlarm = require('./cronAlarm.js');
 var IntervalAlarm = require('./intervalAlarm.js');
 var Sanitizer = require('./sanitizer');
 
-module.exports = function(logger, triggerDB, redisClient) {
+module.exports = function(logger, triggerDB, redisClient, discoverNode) {
 
     this.triggers = {};
     this.endpointAuth = process.env.ENDPOINT_AUTH;
@@ -22,6 +22,7 @@ module.exports = function(logger, triggerDB, redisClient) {
     this.uriHost ='https://' + this.routerHost + ':443';
     this.sanitizer = new Sanitizer(logger, triggerDB, this.uriHost);
     this.monitorStatus = {};
+    this.discover = discoverNode;
 
     var retryDelay = constants.RETRY_DELAY;
     var retryAttempts = constants.RETRY_ATTEMPTS;
@@ -159,7 +160,11 @@ module.exports = function(logger, triggerDB, redisClient) {
     };
 
     this.shouldFireTrigger = function(trigger) {
-        return trigger.monitor || utils.activeHost === utils.host;
+        if (!trigger.monitor && utils.discover){
+            return utils.discover.me.isMaster;
+        } else {
+            return trigger.monitor || utils.activeHost === utils.host;
+        }
     };
 
     this.hasTriggersRemaining = function(trigger) {


### PR DESCRIPTION
about #133 


## Summary
One socket is created which connects the nodes using unicast and elects a master node.
Only the master fires the trigger. If the master node dies, elects another master.

## Advantage
- We can build redanduncy with n. (Currently, only two)
- Dependency with redis can be removed.
- No external health check manager is required.

## Configuration
1. `DISCOVER_DESTINATIONS`
  - Environment variable that turns this pr on/off.
  - If there is no value in this environment variable, the socket does not created, and the trigger execution logic functions as it did in the past(`activehost===host`).
  - Input the addresses of the nodes separated by a comma.
ex) `DISCOVER_DESTINATIONS=host0.alarm.io,host1.alarm.io,host2.alarm.io`


2. `DISCOVER_ADDRESS `,`DISCOVER_PORT `
  - The ip address and port where the socket is created.

3. `DISCOVER_MASTER_TIMEOUT `, `DISCOVER_NODE_TIMEOUT `, `DISCOVER_CHECK_INTERVAL`, `DISCOVER_HELLO_INTERVAL`
  - It is configuration for health check interval and timeout.
  - The following conditions must be met:
`DISCOVER_MASTER_TIMEOUT ` >= `DISCOVER_NODE_TIMEOUT ` >= `DISCOVER_CHECK_INTERVAL` > `DISCOVER_HELLO_INTERVAL`

## Compatibility
If this option is turned off, it can still be used as it was.


