### PR TITLE
Fix spray-json import to comply with newer versions.

### DIFF
--- a/tests/src/test/scala/system/health/AlarmsHealthFeedTests.scala
+++ b/tests/src/test/scala/system/health/AlarmsHealthFeedTests.scala
@@ -20,8 +20,8 @@ import common._
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
-import spray.json.DefaultJsonProtocol.{IntJsonFormat, LongJsonFormat, StringJsonFormat}
-import spray.json.pimpAny
+import spray.json.DefaultJsonProtocol._
+import spray.json._
 
 /**
  * Tests for alarms trigger service

--- a/tests/src/test/scala/system/packages/AlarmsFeedNegativeTests.scala
+++ b/tests/src/test/scala/system/packages/AlarmsFeedNegativeTests.scala
@@ -20,8 +20,8 @@ import common._
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
-import spray.json.DefaultJsonProtocol.{BooleanJsonFormat, IntJsonFormat, LongJsonFormat, StringJsonFormat}
-import spray.json.{JsString, pimpAny}
+import spray.json.DefaultJsonProtocol._
+import spray.json._
 
 /**
  * Tests for alarms trigger service

--- a/tests/src/test/scala/system/packages/AlarmsFeedTests.scala
+++ b/tests/src/test/scala/system/packages/AlarmsFeedTests.scala
@@ -20,8 +20,8 @@ import common._
 import org.junit.runner.RunWith
 import org.scalatest.{FlatSpec, Inside}
 import org.scalatest.junit.JUnitRunner
-import spray.json.DefaultJsonProtocol.{BooleanJsonFormat, IntJsonFormat, LongJsonFormat, StringJsonFormat}
-import spray.json.{JsObject, JsString, pimpAny}
+import spray.json.DefaultJsonProtocol._
+import spray.json._
 
 /**
  * Tests for alarms trigger service

--- a/tests/src/test/scala/system/packages/AlarmsMultiWorkersTests.scala
+++ b/tests/src/test/scala/system/packages/AlarmsMultiWorkersTests.scala
@@ -24,9 +24,8 @@ import common._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{FlatSpec, Matchers}
-import spray.json.DefaultJsonProtocol.StringJsonFormat
 import spray.json.DefaultJsonProtocol._
-import spray.json.{pimpAny, _}
+import spray.json._
 import whisk.core.WhiskConfig
 import whisk.core.database.test.ExtendedCouchDbRestClient
 import whisk.utils.{JsHelpers, retry}


### PR DESCRIPTION
Needed to upgrade spray versions to 1.3.4. Refer to https://github.com/spray/spray-json/releases/tag/v1.3.4.