### PR TITLE
allow apihost port to be configurable

### DIFF
--- a/provider/lib/utils.js
+++ b/provider/lib/utils.js
@@ -19,7 +19,7 @@ module.exports = function(logger, triggerDB, redisClient) {
     this.redisClient = redisClient;
     this.redisHash = triggerDB.config.db + '_' + this.worker;
     this.redisKey = constants.REDIS_KEY;
-    this.uriHost ='https://' + this.routerHost + ':443';
+    this.uriHost ='https://' + this.routerHost;
     this.sanitizer = new Sanitizer(logger, triggerDB, this.uriHost);
     this.monitorStatus = {};
 


### PR DESCRIPTION
Do not hardcode port to 443 which is the default anyways.  If not 443 it should be appended to end of ROUTER_HOST environment var. 