### PR TITLE
pin cron npm module version

### DIFF
--- a/action/alarmWeb_package.json
+++ b/action/alarmWeb_package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "main": "alarmWebAction.js",
   "dependencies" : {
-    "cron": "^1.2.1"
+    "cron": "1.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.15.0",
-    "cron": "^1.1.0",
+    "cron": "1.4.1",
     "express": "^4.13.4",
     "lodash": "^4.5.0",
     "nano": "6.4.2",


### PR DESCRIPTION
A recent regression introduced in node-cron (https://github.com/kelektiv/node-cron) version 1.4.0 broke the alarms provider.  Pin the version to 1.4.1 which has the fix.