### PR TITLE
check if we should disable trigger for status codes on error object

### DIFF
--- a/provider/lib/utils.js
+++ b/provider/lib/utils.js
@@ -113,11 +113,15 @@ module.exports = function(logger, triggerDB, redisClient) {
                             triggerData.triggersLeft++;
                         }
 
-                        if (!error && shouldDisableTrigger(statusCode)) {
-                            //disable trigger
-                            var message = 'Automatically disabled after receiving a ' + statusCode + ' status code when firing the trigger';
-                            disableTrigger(triggerIdentifier, statusCode, message);
-                            reject('Disabled trigger ' + triggerIdentifier + ' due to status code: ' + statusCode);
+                        if (statusCode && shouldDisableTrigger(statusCode)) {
+                            var message;
+                            try {
+                                message = error.error.errorMessage;
+                            } catch (e) {
+                                message = `Received a ${statusCode} status code when firing the trigger`;
+                            }
+                            disableTrigger(triggerIdentifier, statusCode, `Trigger automatically disabled: ${message}`);
+                            reject(`Disabled trigger ${triggerIdentifier}: ${message}`);
                         }
                         else {
                             if (retryCount < retryAttempts) {


### PR DESCRIPTION
Currently a trigger disable check is only done for status codes on response object.  With this update it is also checked when status codes exist on the error object.