### PR TITLE
Use authKey from action parameters instead of __OW_API_KEY

### DIFF
--- a/action/lib/common.js
+++ b/action/lib/common.js
@@ -50,7 +50,6 @@ function createWebParams(rawParams) {
     delete webparams.apihost;
 
     webparams.triggerName = triggerName;
-    webparams.authKey = process.env.__OW_API_KEY;
     config.addAdditionalData(webparams);
 
     return webparams;


### PR DESCRIPTION
This is needed to keep current behavior in preparation for the following PR:
https://github.com/apache/incubator-openwhisk/pull/4284