### PR TITLE
bug fix: give both tags to `docker tag`

### DIFF
--- a/tools/travis/deploy.sh
+++ b/tools/travis/deploy.sh
@@ -37,7 +37,7 @@ if [ ${dockerhub_image_tag} == "latest" ]; then
   dockerhub_githash_image="${dockerhub_image_prefix}/${dockerhub_image_name}:${short_commit}"
 
   echo docker tag ${dockerhub_image} ${dockerhub_githash_image}
-  docker tag ${dockerhub_githash_image}
+  docker tag ${dockerhub_image} ${dockerhub_githash_image}
 
   echo docker push ${dockerhub_githash_image}
   docker push ${dockerhub_githash_image}


### PR DESCRIPTION
Take two.  Got the tag command right in the echo, but botched the actual command in #185 