### PR TITLE
Add --quiet/-q to recursive zip commands

### DIFF
--- a/installCatalog.sh
+++ b/installCatalog.sh
@@ -80,7 +80,7 @@ if [ -e alarmFeed.zip ]; then
 fi
 
 cp -f alarmFeed_package.json package.json
-zip -r alarmFeed.zip lib package.json alarm.js
+zip -r alarmFeed.zip lib package.json alarm.js -q
 
 $WSK_CLI -i --apihost "$EDGEHOST" action update --kind "$ACTION_RUNTIME_VERSION" --auth "$AUTH" alarms/alarm "$PACKAGE_HOME/action/alarmFeed.zip" \
      -a description 'Fire trigger when alarm occurs' \
@@ -122,7 +122,7 @@ if [ -e alarmWebAction.zip ]; then
     rm -rf alarmWebAction.zip
 fi
 
-zip -r alarmWebAction.zip lib package.json alarmWebAction.js node_modules
+zip -r alarmWebAction.zip lib package.json alarmWebAction.js node_modules -q
 
 $WSK_CLI -i --apihost "$EDGEHOST" action update --kind "$ACTION_RUNTIME_VERSION" --auth "$AUTH" alarmsWeb/alarmWebAction "$PACKAGE_HOME/action/alarmWebAction.zip" \
     -a description 'Create/Delete a trigger in alarms provider Database' \


### PR DESCRIPTION
This commit makes the zip command not output lines of all the
files it adds in the compressed file.
The lines can reach to thousand of lines without the -q option.
This makes it easy to scroll through the progress of the script.