### PR TITLE
Make cron triggers fire with random delay with parameter `strict`

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The following is an example of creating a trigger that will be fired once on Dec
 The `/whisk.system/alarms/alarm` feed configures the Alarm service to fire a Trigger event at a specified frequency. The parameters are as follows:
 
 - `cron` (*required*): A string, based on the UNIX crontab syntax that indicates when to fire the Trigger in Coordinated Universal Time (UTC). The string is a sequence of five fields that are separated by spaces: `X X X X X`.
-For more information, see: http://crontab.org. The following strings are examples that use varying duration's of frequency.
+  For more information, see: http://crontab.org. The following strings are examples that use varying duration's of frequency.
 
   - `* * * * *`: The Trigger fires at the top of every minute.
   - `0 * * * *`: The Trigger fires at the top of every hour.
@@ -101,6 +101,7 @@ For more information, see: http://crontab.org. The following strings are example
   **Note**: The parameter `cron` supports five or six fields.  Not all OpenWhisk vendors may support 6 fields so please check their documentation for support.
   For more details about using this custom cron syntax, see: https://github.com/ncb000gt/node-cron.
   Here is an example using six fields notation:
+
     - `*/30 * * * * *`: every thirty seconds.
 
 - `trigger_payload` (*optional*): The value of this parameter becomes the content of the Trigger every time the Trigger is fired.
@@ -126,6 +127,15 @@ January 1, 2019, 00:00:00 UTC and will stop firing January 31, 2019, 23:59:00 UT
   ```
 
  **Note**: The parameter `maxTriggers` is deprecated and will be removed soon.  To stop the Trigger, use the `stopDate` parameter.
+
+- `strict` (*optional*): A boolean value that decides to add a few seconds to the Trigger. This work with only five-field cron alarms.
+
+  - If it's true, the Trigger will fire at the top of the hour/minute (\**:**:00).
+  - Otherwise, the Trigger will fire after the specific seconds (\**:**:00-59).
+
+The delay is determined by the hash value of the Trigger's name, so it keeps the same interval before and after the (re)deployment.
+
+**Note** This option can be helpful to avoid thundering herds when the second-unit errors are not critical.
 
 # Building from Source
 

--- a/action/alarmWebAction.js
+++ b/action/alarmWebAction.js
@@ -103,7 +103,7 @@ function main(params) {
                     }
                     newTrigger.cron = params.cron;
                     newTrigger.timezone = params.timezone;
-                    newTrigger.strict = params.strict !== false;
+                    newTrigger.strict = params.strict === 'true';
                 } catch(ex) {
                     var message = ex.message !== 'Invalid timezone.' ? `cron pattern '${params.cron}' is not valid` : ex.message;
                     return common.sendError(400, message);

--- a/action/alarmWebAction.js
+++ b/action/alarmWebAction.js
@@ -103,6 +103,7 @@ function main(params) {
                     }
                     newTrigger.cron = params.cron;
                     newTrigger.timezone = params.timezone;
+                    newTrigger.strict = params.strict !== false;
                 } catch(ex) {
                     var message = ex.message !== 'Invalid timezone.' ? `cron pattern '${params.cron}' is not valid` : ex.message;
                     return common.sendError(400, message);

--- a/installCatalog.sh
+++ b/installCatalog.sh
@@ -84,7 +84,7 @@ zip -r alarmFeed.zip lib package.json alarm.js -q
 
 $WSK_CLI -i --apihost "$EDGEHOST" action update --kind "$ACTION_RUNTIME_VERSION" --auth "$AUTH" alarms/alarm "$PACKAGE_HOME/action/alarmFeed.zip" \
      -a description 'Fire trigger when alarm occurs' \
-     -a parameters '[ {"name":"cron", "required":true}, {"name":"timezone", "required":false}, {"name":"startDate", "required":false}, {"name":"stopDate", "required":false} ]' \
+     -a parameters '[ {"name":"cron", "required":true}, {"name":"timezone", "required":false}, {"name":"startDate", "required":false}, {"name":"stopDate", "required":false}, {"name":"strict", "required":false} ]' \
      -a feed true
 
 $WSK_CLI -i --apihost "$EDGEHOST" action update --kind "$ACTION_RUNTIME_VERSION" --auth "$AUTH" alarms/once "$PACKAGE_HOME/action/alarmFeed.zip" \

--- a/provider/lib/cronAlarm.js
+++ b/provider/lib/cronAlarm.js
@@ -94,7 +94,7 @@ module.exports = function(logger, newTrigger) {
             hash = ((hash << 5) - hash) + char;
         }
         hash %= 60;
-        hash = hash < 0 ? -hash : hash;
+        hash = Math.abs(hash);
 
         return hash.toString(10);
     }

--- a/provider/lib/cronAlarm.js
+++ b/provider/lib/cronAlarm.js
@@ -22,7 +22,7 @@ var constants = require('./constants.js');
 module.exports = function(logger, newTrigger) {
 
     var maxTriggers = newTrigger.maxTriggers || constants.DEFAULT_MAX_TRIGGERS;
-    var delayLimit = validateLimit(process.env.ALARM_DELAY_LIMIT) || 0;
+    var delayLimit = validateLimit(parseInt(process.env.ALARM_DELAY_LIMIT)) || 0;
 
     var cachedTrigger = {
         apikey: newTrigger.apikey,
@@ -103,8 +103,10 @@ module.exports = function(logger, newTrigger) {
     function distributeCron(trigger) {
         var cronFields = (trigger.cron + '').trim().split(/\s+/);
 
-        if (trigger.strict === false && cronFields.length === 5 && delayLimit === 0) {
-            return cronFields.splice(0, 0, hashName(trigger.name)).join(' ');
+        var cronFields = (trigger.cron + '').trim().split(/\s+/);
+        if (trigger.strict !== 'true' && cronFields.length === 5 && delayLimit !== 0) {
+            var newCron = [hashName(trigger.name), ...cronFields].join(' ');
+            return newCron;
         }
 
         return trigger.cron;

--- a/provider/lib/cronAlarm.js
+++ b/provider/lib/cronAlarm.js
@@ -85,6 +85,7 @@ module.exports = function(logger, newTrigger) {
         }
     };
 
+    // Convert string to integer in [0, 60)
     function hashName(name) {
         var hash = 0;
 

--- a/provider/lib/cronAlarm.js
+++ b/provider/lib/cronAlarm.js
@@ -101,11 +101,12 @@ module.exports = function(logger, newTrigger) {
     }
 
     function distributeCron(trigger) {
-        var cronFields = (trigger.cron + '').trim().split(/\s+/);
+        var method = "distributeCronAlarm"
 
         var cronFields = (trigger.cron + '').trim().split(/\s+/);
         if (trigger.strict !== 'true' && cronFields.length === 5 && delayLimit !== 0) {
             var newCron = [hashName(trigger.name), ...cronFields].join(' ');
+            logger.info(method, trigger.triggerID, 'is converted to', '"' + newCron + '"');
             return newCron;
         }
 

--- a/provider/lib/cronAlarm.js
+++ b/provider/lib/cronAlarm.js
@@ -101,7 +101,7 @@ module.exports = function(logger, newTrigger) {
     }
 
     function distributeCron(trigger) {
-        var method = "distributeCronAlarm"
+        var method = "distributeCronAlarm";
 
         var cronFields = (trigger.cron + '').trim().split(/\s+/);
         if (trigger.strict !== 'true' && cronFields.length === 5 && delayLimit !== 0) {


### PR DESCRIPTION
I made an implementation of what I suggested in #196 
A parameter `strict` is added in `alarms/alarm` feed to enable the firing distribution.
If user passes the boolean value `true` (or nothing; it's default), firing will act like usual.
Distribution is only enabled when `strict=false` is passed.