### PR TITLE
Changes to support CosmosDB as trigger store

### DIFF
--- a/action/alarmWebAction.js
+++ b/action/alarmWebAction.js
@@ -34,7 +34,7 @@ function main(params) {
         additionalData: common.constructObject(params.additionalData),
     };
     var triggerID = new Database().constructTriggerID(getDBConfig(params), triggerData);
-    
+
     var workers = params.workers instanceof Array ? params.workers : [];
     var deleteAfterFireArray = ['false', 'true', 'rules'];
     var db;
@@ -149,7 +149,7 @@ function main(params) {
                 return getDatabase(getDBConfig(params));
             })
             .then((database) => {
-                db = database
+                db = database;
                 return db.getWorkerID(workers);
             })
             .then((worker) => {
@@ -178,7 +178,7 @@ function main(params) {
                 return getDatabase(getDBConfig(params));
             })
             .then((database) => {
-                db = database
+                db = database;
                 return db.getTrigger(triggerID);
             })
             .then(doc => {
@@ -231,7 +231,7 @@ function main(params) {
                 return getDatabase(getDBConfig(params));
             })
             .then((database) => {
-                db = database
+                db = database;
                 return db.getTrigger(triggerID);
             })
             .then(trigger => {
@@ -352,7 +352,7 @@ function main(params) {
                 return getDatabase(getDBConfig(params));
             })
             .then((database) => {
-                db = database
+                db = database;
                 return db.getTrigger(triggerID);
             })
             .then(trigger => {

--- a/action/alarmWeb_package.json
+++ b/action/alarmWeb_package.json
@@ -2,7 +2,10 @@
   "name": "alarmWebAction",
   "version": "1.0.0",
   "main": "alarmWebAction.js",
-  "dependencies" : {
-    "cron": "1.4.1"
+  "dependencies": {
+    "cron": "1.4.1",
+    "documentdb": "^1.14.5",
+    "moment": "^2.12.0",
+    "nano": "6.4.2"
   }
 }

--- a/action/lib/config.js
+++ b/action/lib/config.js
@@ -5,10 +5,11 @@ function getOpenWhiskConfig(triggerData) {
     return {ignore_certs: true, namespace: triggerData.namespace, api_key: triggerData.apikey};
 }
 
-function constructTriggerID(triggerData) {
-    var triggerID = `${triggerData.namespace}/${triggerData.name}`;
+function constructTriggerID(triggerData, supportsSlash) {
+    var sep = supportsSlash ? '/' : '|';
+    var triggerID = `${triggerData.namespace}${sep}${triggerData.name}`;
     if (triggerData.apikey) {
-        triggerID = `${triggerData.apikey}/${triggerID}`;
+        triggerID = `${triggerData.apikey}${sep}${triggerID}`;
     }
     return triggerID;
 }

--- a/action/lib/cosmosdb.js
+++ b/action/lib/cosmosdb.js
@@ -1,0 +1,238 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+const common = require('./common');
+
+module.exports = function(endpoint, masterKey) {
+    var DocumentClient = require('documentdb').DocumentClient;
+    var client = new DocumentClient(endpoint, {masterKey: masterKey});
+    
+    this.client = client;
+    var utilsDB = this;
+    
+    this.init = function(databaseName, collectionName) {
+        console.log("cosmosdb.init");
+        let querySpec = {
+            query: 'SELECT * FROM root r WHERE r.id = @id',
+            parameters: [{ name: '@id', value: databaseName }]
+        };
+        return new Promise((resolve, reject) => {
+            client.queryDatabases(querySpec).toArray((err, results) => {
+                if(err) {
+                    reject(err);
+                } else {
+                    console.log(`cosmosdb client initialized successfully:`, results[0]._self);
+                    utilsDB.dbLink = results[0]._self;
+                    utilsDB.getDatabase(collectionName)
+                    .then((col) => {
+                        resolve();
+                    });
+                }
+            });
+        });
+    };
+    
+    //get collection in cosmosdb terminology
+    this.getDatabase = function(collectionName) {
+        console.log(`cosmosdb.getDatabase:`, collectionName);
+        let querySpec = {
+            query: 'SELECT * FROM root r WHERE r.id=@id',
+            parameters: [{ name: '@id', value: collectionName }]
+        };
+        return new Promise((resolve, reject) => {
+            client.queryCollections(utilsDB.dbLink, querySpec).toArray((err, results) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    if (results.length === 0) {
+                        console.log("No valid collection. Create One");
+                        utilsDB.createDatabase(collectionName)
+                        .then((col) => {
+                            console.log(`createdDatabase:`,col);
+                            utilsDB.collectionLink = col._self;
+                            resolve(col);
+                        });
+                    } else {
+                        console.log(`Found valid collection:`, results[0]._self);
+                        utilsDB.collectionLink = results[0]._self;
+                        resolve(results);
+                    }
+                    
+                }
+            });
+        });
+    };
+    
+    //create collection in cosmosdb terminology
+    this.createDatabase = function(collectionName) {
+        console.log(`cosmosdb.createDatabase:`,collectionName);
+        var collectionDefinition = { id: collectionName };
+        return new Promise((resolve, reject) => {
+            client.createCollection(utilsDB.dbLink, collectionDefinition, function(err, collection) {
+                if(err) {
+                    console.log(`cosmosdb.createDatabase failed:`, err);
+                    reject(err);
+                } else {
+                    console.log(`cosmosdb.createDatabase created:`,collection);
+                    utilsDB.collectionLink = collection._self;
+                    resolve(collection);
+                }
+            });
+        });
+    };
+    
+    this.getWorkerID = function(availabeWorkers) {
+        
+        return new Promise((resolve, reject) => {
+            var workerID = availabeWorkers[0] || 'worker0';
+            resolve(workerID);
+        });
+    };
+    
+    this.createTrigger = function(triggerID, newTrigger) {
+        console.log(`cosmosdb.createTrigger:`, triggerID);
+        if(!newTrigger.id) {
+            console.log("add id to doc");
+            newTrigger.id = triggerID;
+        }
+        
+        return new Promise(function(resolve, reject) {
+            
+            client.createDocument(utilsDB.collectionLink, newTrigger, function(err, document) {
+                if(err) {
+                    console.error(`cosmosdb.createTrigger failed:`, err);
+                    reject(err);
+                } else {
+                    console.log(`cosmosdb.createTrigger created:`, triggerID);
+                    resolve();
+                }
+            });
+        });
+    };
+    
+    this.getTrigger = function(triggerID, retry = true) {
+        console.log(`cosmosdb.getTrigger:`, triggerID);
+        return new Promise(function(resolve, reject) {
+            let querySpec = {
+                query: 'SELECT * FROM root r WHERE r.id = @id',
+                parameters: [{ name: '@id', value: triggerID }]
+            };
+            
+            client.queryDocuments(utilsDB.collectionLink, querySpec).toArray(function(err, results) {
+                if (err) {
+                    if (retry) {
+                        utilsDB.getTrigger(triggerID, false)
+                        .then(doc => {
+                            resolve(doc);
+                        })
+                        .catch(err => {
+                            reject(err);
+                        });
+                    } else {
+                        reject(common.sendError(err.statusCode, 'could not find trigger ' + triggerID + ' in the database'));
+                    }
+                }
+                
+                if(results.length == 0)
+                resolve();
+                else {
+                    console.log("Found Trigger " + triggerID);
+                    resolve(results[0]);
+                }
+            });
+        });
+    };
+    
+    this.updateTrigger = function(triggerID, trigger, params, retryCount) {
+        console.log(`cosmosdb.updateTrigger:`, triggerID);
+        if (retryCount === 0) {
+            for (var key in params) {
+                trigger[key] = params[key];
+            }
+            var status = {
+                'active': true,
+                'dateChanged': Date.now()
+            };
+            trigger.status = status;
+        }
+        
+        return new Promise(function(resolve, reject) {
+            utilsDB.getTrigger(triggerID)
+            .then((doc) => {
+                client.replaceDocument(doc._self, trigger, function(err, replaced) {
+                    if (err) {
+                        if (err.statusCode === 409 && retryCount < 5) {
+                            setTimeout(function () {
+                                utilsDB.updateTrigger(triggerID, trigger, params, (retryCount + 1))
+                                .then(id => {
+                                    resolve(id);
+                                })
+                                .catch(err => {
+                                    reject(err);
+                                });
+                            }, 1000);
+                        }
+                        else {
+                            console.log(`cosmosdb.updateTrigger failed:`, err);
+                            reject(common.sendError(err.statusCode, 'there was an error while updating the trigger in the database.', err.message));
+                        }
+                    } else {
+                        console.log(`cosmosdb.updateTrigger updated:`, triggerID);
+                        resolve(replaced);
+                    }
+                });
+            });
+        });
+    };
+    
+    this.disableTrigger = function(triggerID, trigger, retryCount, crudMessage) {
+        console.log(`cosmosdb.disableTrigger:`, triggerID);
+        if (retryCount === 0) {
+            //check if it is already disabled
+            if (trigger.status && trigger.status.active === false) {
+                return Promise.resolve(triggerID);
+            }
+            
+            var message = `Automatically disabled trigger while ${crudMessage}`;
+            var status = {
+                'active': false,
+                'dateChanged': Date.now(),
+                'reason': {'kind': 'AUTO', 'statusCode': undefined, 'message': message}
+            };
+            trigger.status = status;
+        }
+        
+        return utilsDB.updateTrigger(triggerID, trigger, {}, retryCount);
+    };
+    
+    this.deleteTrigger = function(triggerID) {
+        console.log(`cosmosdb.deleteTrigger`, triggerID);
+        return new Promise(function(resolve, reject) {
+            utilsDB.getTrigger(triggerID)
+            .then((doc) => {
+                client.deleteDocument(doc._self, function(err) {
+                    if (err) {
+                        console.log(`cosmosdb.deleteTrigger failed:`, err);
+                        reject(err);
+                    } else {
+                        console.log(`cosmosdb.deleteTrigger deleted:`, triggerID);
+                        resolve();
+                    }
+                });
+            });
+        });
+    };
+};

--- a/action/lib/couchdb.js
+++ b/action/lib/couchdb.js
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const common = require('./common');
+
+module.exports = function(dbURL, dbName) {
+    var nano = require('nano')(dbURL);
+    this.db = nano.db.use(dbName);
+    var utilsDB = this;
+
+        this.getWorkerID = function(availabeWorkers) {
+
+        return new Promise((resolve, reject) => {
+            var workerID = availabeWorkers[0] || 'worker0';
+
+            if (availabeWorkers.length > 1) {
+                utilsDB.db.view('triggerViews', 'triggers_by_worker', {reduce: true, group: true}, function (err, body) {
+                    if (!err) {
+                        var triggersByWorker = {};
+
+                        availabeWorkers.forEach(worker => {
+                            triggersByWorker[worker] = 0;
+                        });
+
+                        body.rows.forEach(row => {
+                            if (row.key in triggersByWorker) {
+                                triggersByWorker[row.key] = row.value;
+                            }
+                        });
+
+                        // find which worker has the least number of assigned triggers
+                        for (var worker in triggersByWorker) {
+                            if (triggersByWorker[worker] < triggersByWorker[workerID]) {
+                                workerID = worker;
+                            }
+                        }
+                        resolve(workerID);
+                    } else {
+                        reject(err);
+                    }
+                });
+            }
+            else {
+                resolve(workerID);
+            }
+        });
+    };
+
+    this.createTrigger = function(triggerID, newTrigger) {
+        return new Promise(function(resolve, reject) {
+
+            utilsDB.db.insert(newTrigger, triggerID, function (err) {
+                if (!err) {
+                    resolve();
+                }
+                else {
+                    reject(common.sendError(err.statusCode, 'error creating alarm trigger.', err.message));
+                }
+            });
+        });
+    };
+
+    this.getTrigger = function(triggerID, retry = true) {
+        return new Promise(function(resolve, reject) {
+
+            var qName = triggerID.split('/');
+            var id = retry ? triggerID : qName[0] + '/_/' + qName[2];
+            utilsDB.db.get(id, function (err, existing) {
+                if (err) {
+                    if (retry) {
+                        utilsDB.getTrigger(triggerID, false)
+                        .then(doc => {
+                            resolve(doc);
+                        })
+                        .catch(err => {
+                            reject(err);
+                        });
+                    } else {
+                        var name = '/' + qName[1] + '/' + qName[2];
+                        reject(common.sendError(err.statusCode, 'could not find trigger ' + name + ' in the database'));
+                    }
+                } else {
+                    resolve(existing);
+                }
+            });
+        });
+    };
+
+    this.disableTrigger = function(triggerID, trigger, retryCount, crudMessage) {
+
+        if (retryCount === 0) {
+            //check if it is already disabled
+            if (trigger.status && trigger.status.active === false) {
+                return Promise.resolve(triggerID);
+            }
+
+            var message = `Automatically disabled trigger while ${crudMessage}`;
+            var status = {
+                'active': false,
+                'dateChanged': Date.now(),
+                'reason': {'kind': 'AUTO', 'statusCode': undefined, 'message': message}
+            };
+            trigger.status = status;
+        }
+
+        return new Promise(function(resolve, reject) {
+
+            utilsDB.db.insert(trigger, triggerID, function (err) {
+                if (err) {
+                    if (err.statusCode === 409 && retryCount < 5) {
+                        setTimeout(function () {
+                            utilsDB.disableTrigger(triggerID, trigger, (retryCount + 1))
+                            .then(id => {
+                                resolve(id);
+                            })
+                            .catch(err => {
+                                reject(err);
+                            });
+                        }, 1000);
+                    }
+                    else {
+                        reject(common.sendError(err.statusCode, 'there was an error while disabling the trigger in the database.', err.message));
+                    }
+                }
+                else {
+                    resolve(triggerID);
+                }
+            });
+        });
+
+    };
+
+    this.deleteTrigger = function(triggerID, retryCount) {
+
+        return new Promise(function(resolve, reject) {
+
+            utilsDB.db.get(triggerID, function (err, existing) {
+                if (!err) {
+                    utilsDB.db.destroy(existing._id, existing._rev, function (err) {
+                        if (err) {
+                            if (err.statusCode === 409 && retryCount < 5) {
+                                setTimeout(function () {
+                                    utilsDB.deleteTrigger(triggerID, (retryCount + 1))
+                                    .then(resolve)
+                                    .catch(err => {
+                                        reject(err);
+                                    });
+                                }, 1000);
+                            }
+                            else {
+                                reject(common.sendError(err.statusCode, 'there was an error while deleting the trigger from the database.', err.message));
+                            }
+                        }
+                        else {
+                            resolve();
+                        }
+                    });
+                }
+                else {
+                    var qName = triggerID.split('/');
+                    var name = '/' + qName[1] + '/' + qName[2];
+                    reject(common.sendError(err.statusCode, 'could not find trigger ' + name + ' in the database'));
+                }
+            });
+        });
+    };
+
+    this.updateTrigger = function(triggerID, trigger, params, retryCount) {
+
+         if (retryCount === 0) {
+            for (var key in params) {
+                trigger[key] = params[key];
+            }
+            var status = {
+                'active': true,
+                'dateChanged': Date.now()
+            };
+            trigger.status = status;
+        }
+
+        return new Promise(function(resolve, reject) {
+            utilsDB.db.insert(trigger, triggerID, function (err) {
+                if (err) {
+                    if (err.statusCode === 409 && retryCount < 5) {
+                        setTimeout(function () {
+                            utilsDB.updateTrigger(triggerID, trigger, params, (retryCount + 1))
+                            .then(id => {
+                                resolve(id);
+                            })
+                            .catch(err => {
+                                reject(err);
+                            });
+                        }, 1000);
+                    }
+                    else {
+                        reject(common.sendError(err.statusCode, 'there was an error while updating the trigger in the database.', err.message));
+                    }
+                }
+                else {
+                    resolve(triggerID);
+                }
+            });
+        });
+    };
+
+};

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "redis": "^2.7.1",
     "bluebird": "^3.5.0",
     "systeminformation": "^3.19.0",
-    "long-timeout": "^0.1.1"
+    "long-timeout": "^0.1.1",
+    "documentdb": "^1.14.5"
   }
 }

--- a/provider/lib/cosmosdb.js
+++ b/provider/lib/cosmosdb.js
@@ -1,0 +1,289 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const EventEmitter = require('events');
+
+module.exports = function(endpoint, masterKey) {
+    var DocumentClient = require('documentdb').DocumentClient;
+    var client = new DocumentClient(endpoint, {masterKey: masterKey});
+    this.dbFeedEvents = new DBFeed();
+    this.feed_etag = -1;
+    this.feedCheckInterval = 60000; //every 1 min
+    this.client = client;
+    var utilsDB = this;
+
+    this.init = function(databaseName) {
+        let querySpec = {
+            query: 'SELECT * FROM root r WHERE r.id = @id',
+            parameters: [{ name: '@id', value: databaseName }]
+        };
+        return new Promise((resolve, reject) => {
+        client.queryDatabases(querySpec).toArray((err, results) => {
+            if(err){
+                reject(err);
+            } else {
+                console.log("cosmosdb client initialized successfully");
+                utilsDB.dbLink = results[0]._self;
+                if(process.env.COSMOSDB_FEED_INTERVAL)
+                    utilsDB.feedCheckInterval = process.env.COSMOSDB_FEED_INTERVAL;
+                resolve();
+            }
+        });
+        });
+    };
+
+    //get or create collection in cosmosdb terminology
+    this.createDatabase = function(log, collectionName) {
+        var method = 'createDatabase';
+        let logger = log;
+        logger.info(method, 'creating the trigger database');
+        let querySpec = {
+            query: 'SELECT * FROM root r WHERE r.id=@id',
+            parameters: [{ name: '@id', value: collectionName }]
+        };
+        return new Promise((resolve, reject) => {
+            client.queryCollections(utilsDB.dbLink, querySpec).toArray((err, results) => {
+            if (err) {
+                reject(err);
+            }
+            else {
+                if (results.length === 0) {
+                logger.info(method, "No Trigger database found. Creating one.");
+                createDB(collectionName)
+                    .then((col) => {
+                        logger.info(method, "created trigger database.");
+                        utilsDB.collectionLink = col._self;
+                    });
+                } else {
+                    utilsDB.collectionLink = results[0]._self;
+                    utilsDB.prefix = results[0].id;
+                }
+                checkFeed();
+                resolve(utilsDB);
+            }
+            });
+        });
+    };
+
+       //create collection in cosmosdb terminology
+    function createDB (collectionName) {
+        var collectionDefinition = { id: collectionName };
+        return new Promise((resolve, reject) => {
+            client.createCollection(utilsDB.dbLink, collectionDefinition, function(err, collection) {
+                if(err) reject(err);
+
+                console.log("Created collection");
+                utilsDB.collectionLink = collection._self;
+                resolve(collection);
+            });
+        });
+    }
+
+
+    this.createTrigger = function(triggerID, newTrigger) {
+        if(!newTrigger.id) {
+            console.log("add id to doc");
+            newTrigger.id = triggerID;
+        }
+
+        return new Promise(function(resolve, reject) {
+
+            client.createDocument(utilsDB.collectionLink, newTrigger, function(err, document) {
+            if(err) reject(err);
+
+            console.log("created trigger " + triggerID);
+            resolve();
+        });
+        });
+    };
+
+    this.getTrigger = function(triggerID, retry = true) {
+        return new Promise(function(resolve, reject) {
+            let querySpec = {
+                query: 'SELECT * FROM root r WHERE r.id = @id',
+                parameters: [{ name: '@id', value: triggerID }]
+            };
+
+            client.queryDocuments(utilsDB.collectionLink, querySpec).toArray(function(err, results) {
+            if (err) {
+                if(retry) {
+                    utilsDB.getTrigger(triggerID, false)
+                    .then(doc => {
+                        resolve(doc);
+                    })
+                    .catch(err => {
+                        reject(err);
+                    });
+                }
+                else {
+                    reject(err);
+                }
+            } else {
+                if(results.length == 0)
+                    resolve();
+                else {
+                    resolve(results[0]);
+                }
+            }
+            });
+        });
+    };
+
+    this.disableTrigger = function(triggerID, trigger, retryCount, crudMessage) {
+        if (retryCount === 0) {
+            //check if it is already disabled
+            if (trigger.status && trigger.status.active === false) {
+                return Promise.resolve(triggerID);
+            }
+
+            var message = `Automatically disabled trigger while ${crudMessage}`;
+            var status = {
+                'active': false,
+                'dateChanged': Date.now(),
+                'reason': {'kind': 'AUTO', 'statusCode': undefined, 'message': message}
+            };
+            trigger.status = status;
+        }
+
+        return new Promise(function(resolve, reject) {
+
+        });
+
+    };
+
+    this.deleteTrigger = function(triggerID) {
+
+        return new Promise(function(resolve, reject) {
+            utilsDB.getTrigger(triggerID)
+                .then((doc) => {
+                    client.deleteDocument(doc._self, function(err) {
+                    if (err) reject(err);
+
+                    console.log("Deleted Trigger " + triggerID);
+                    resolve();
+                    });
+                })
+                .catch((err) => { reject(err);});
+        });
+    };
+
+    this.updateTrigger = function(triggerID, trigger, params, retryCount) {
+        if (retryCount === 0) {
+            for (var key in params) {
+                trigger[key] = params[key];
+            }
+            var status = {
+                'active': true,
+                'dateChanged': Date.now()
+            };
+            trigger.status = status;
+        }
+
+        if(!trigger.id) {
+            trigger.id = triggerID;
+        }
+
+        return new Promise(function(resolve, reject) {
+            utilsDB.getTrigger(triggerID)
+                .then((doc) => {
+                    client.replaceDocument(doc._self, trigger, function(err, replaced) {
+                    if (err) reject(err);
+
+                    console.log("Updated Trigger " + triggerID);
+                    resolve(replaced);
+                    });
+                })
+                .catch((err) => { reject(err);});
+        });
+    };
+
+    this.getTriggerByWorkers = function(viewDDName, triggersByWorker, worker) {
+        return new Promise(function(resolve, reject) {
+
+            let querySpec = {
+                query: 'SELECT * FROM root r WHERE r.worker = @key',
+                parameters: [{ name: '@key', value: worker }]
+            };
+
+            client.queryDocuments(utilsDB.collectionLink, querySpec).toArray(function(err, results) {
+            if (err) {
+                reject(err);
+            } else {
+                if(results.length == 0)
+                resolve();
+                else {
+                    console.log("Found Triggers for worker " + worker);
+                    resolve(results);
+                }
+            }
+            });
+        });
+    };
+
+    this.getPrefix = function() {
+        if(utilsDB.prefix)
+            return utilsDB.prefix;
+
+        return "alarmservice";
+    };
+
+    this.follow = function(func) {
+        return utilsDB.dbFeedEvents;
+    };
+
+    function checkFeed() {
+        setTimeout(function() {
+            checkDBChanges();
+            checkFeed();
+        }, utilsDB.feedCheckInterval);
+    }
+
+    function checkDBChanges(){
+        var options = {
+            a_im: "Incremental feed",
+            accessCondition: {
+                type: "IfNoneMatch",
+                condition: utilsDB.feed_etag
+            }
+        };
+        var query = client.readDocuments(utilsDB.collectionLink, options);
+        query.executeNext((err, results, headers) => {
+
+            if(err) {
+                console.log("Error while fetching DB feed - " + err);
+            }
+            else{
+                if(utilsDB.feed_etag !== -1){
+                    results.forEach(function(item){
+                        var change = {
+                            id: item.id,
+                            doc: item
+                        };
+                        utilsDB.dbFeedEvents.emit("change", change);
+                    });
+                }
+                utilsDB.feed_etag = headers.etag;
+            }
+        });
+    }
+};
+
+class DBFeed extends EventEmitter {
+
+    follow(){
+        //do nothing. This is just to emulate follow method for couchdb feed
+    }
+}

--- a/provider/lib/couchdb.js
+++ b/provider/lib/couchdb.js
@@ -1,0 +1,287 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var constants = require('./constants.js');
+
+var filterDDName = '_design/' + constants.FILTERS_DESIGN_DOC;
+var viewDDName = '_design/' + constants.VIEWS_DESIGN_DOC;
+
+module.exports = function(dbURL) {
+    var nano = require('nano')(dbURL);
+    var utilsDB = this;
+    this.nano = nano;
+
+    this.getPrefix = function() {
+        if(utilsDB.nano)
+            return utilsDB.nano.config.db;
+
+        return "alarmservice";
+    };
+
+    this.createDatabase = function(logger, databaseName) {
+    var method = 'createDatabase';
+    logger.info(method, 'creating the trigger database');
+
+    return new Promise(function (resolve, reject) {
+    if (utilsDB.nano !== null) {
+            utilsDB.nano.db.create(databaseName, function (err, body) {
+                if (!err) {
+                    logger.info(method, 'created trigger database:', databaseName);
+                }
+                else if (err.statusCode !== 412) {
+                    logger.info(method, 'failed to create trigger database:', databaseName, err);
+                }
+
+                var viewDD = {
+                    views: {
+                        triggers_by_worker: {
+                            map: function (doc) {
+                                if (doc.maxTriggers && (!doc.status || doc.status.active === true)) {
+                                    emit(doc.worker || 'worker0', 1);
+                                }
+                            }.toString(),
+                            reduce: '_count'
+                        }
+                    }
+                };
+
+                createDesignDoc(nano.db.use(databaseName), viewDDName, viewDD)
+                .then((db) => {
+                    var filterDD = {
+                        filters: {
+                            triggers_by_worker:
+                                function (doc, req) {
+                                    return doc.maxTriggers && ((!doc.worker && req.query.worker === 'worker0') ||
+                                            (doc.worker === req.query.worker));
+                                }.toString()
+                        }
+                    };
+                    return createDesignDoc(db, filterDDName, filterDD);
+                })
+                .then((db) => {
+                  utilsDB.nano = db;
+                  resolve(utilsDB);
+                })
+                .catch((err) => {
+                    reject(err);
+                });
+
+            });
+    }
+    else {
+        console.log(" check db URL");
+        reject('nano provider did not get created.  check db URL: ' + dbURL);
+    }
+    });
+    };
+
+    function createDesignDoc(db, ddName, designDoc) {
+        var method = 'createDesignDoc';
+
+        return new Promise(function(resolve, reject) {
+
+            db.get(ddName, function (error, body) {
+                if (error) {
+                    //new design doc
+                    db.insert(designDoc, ddName, function (error, body) {
+                        if (error && error.statusCode !== 409) {
+                            reject('design doc could not be created: ' + error);
+                        }
+                        else {
+                            resolve(db);
+                        }
+                    });
+                }
+                else {
+                    resolve(db);
+                }
+            });
+        });
+    }
+
+    this.createTrigger = function(triggerID, newTrigger) {
+    return new Promise(function(resolve, reject) {
+
+        utilsDB.nano.insert(newTrigger, triggerID, function (err) {
+            if (!err) {
+                resolve();
+            }
+            else {
+                reject(err.statusCode + 'error creating alarm trigger.' + err.message);
+            }
+        });
+    });
+    };
+
+    this.getTrigger = function(triggerID, retry = true) {
+        return new Promise(function(resolve, reject) {
+
+            var qName = triggerID.split('/');
+            var id = retry ? triggerID : qName[0] + '/_/' + qName[2];
+            utilsDB.nano.get(id, function (err, existing) {
+                if (err) {
+                    if (retry) {
+                        utilsDB.getTrigger(triggerID, false)
+                        .then(doc => {
+                            resolve(doc);
+                        })
+                        .catch(err => {
+                            reject(err);
+                        });
+                    } else {
+                        var name = '/' + qName[1] + '/' + qName[2];
+                        reject(err.statusCode + 'could not find trigger ' + name + ' in the database');
+                    }
+                } else {
+                    resolve(existing);
+                }
+            });
+        });
+    };
+
+    this.disableTrigger = function(triggerID, trigger, retryCount, crudMessage) {
+
+        if (retryCount === 0) {
+            //check if it is already disabled
+            if (trigger.status && trigger.status.active === false) {
+                return Promise.resolve(triggerID);
+            }
+
+            var message = `Automatically disabled trigger while ${crudMessage}`;
+            var status = {
+                'active': false,
+                'dateChanged': Date.now(),
+                'reason': {'kind': 'AUTO', 'statusCode': undefined, 'message': message}
+            };
+            trigger.status = status;
+        }
+
+        return new Promise(function(resolve, reject) {
+
+            utilsDB.nano.insert(trigger, triggerID, function (err) {
+                if (err) {
+                    if (err.statusCode === 409 && retryCount < 5) {
+                        setTimeout(function () {
+                            utilsDB.disableTrigger(triggerID, trigger, (retryCount + 1))
+                            .then(id => {
+                                resolve(id);
+                            })
+                            .catch(err => {
+                                reject(err);
+                            });
+                        }, 1000);
+                    }
+                    else {
+                        reject(err.statusCode + 'there was an error while disabling the trigger in the database.' + err.message);
+                    }
+                }
+                else {
+                    resolve(triggerID);
+                }
+            });
+        });
+
+    };
+
+    this.deleteTrigger = function(triggerID, retryCount) {
+
+        return new Promise(function(resolve, reject) {
+
+            utilsDB.nano.get(triggerID, function (err, existing) {
+                if (!err) {
+                    utilsDB.nano.destroy(existing._id, existing._rev, function (err) {
+                        if (err) {
+                            if (err.statusCode === 409 && retryCount < 5) {
+                                setTimeout(function () {
+                                    utilsDB.deleteTrigger(triggerID, (retryCount + 1))
+                                    .then(resolve)
+                                    .catch(err => {
+                                        reject(err);
+                                    });
+                                }, 1000);
+                            }
+                            else {
+                                reject(err.statusCode + 'there was an error while deleting the trigger from the database.' + err.message);
+                            }
+                        }
+                        else {
+                            resolve();
+                        }
+                    });
+                }
+                else {
+                    var qName = triggerID.split('/');
+                    var name = '/' + qName[1] + '/' + qName[2];
+                    reject(err.statusCode + 'could not find trigger ' + name + ' in the database');
+                }
+            });
+        });
+    };
+
+    this.updateTrigger = function(triggerID, trigger, params, retryCount) {
+
+         if (retryCount === 0) {
+            for (var key in params) {
+                trigger[key] = params[key];
+            }
+            var status = {
+                'active': true,
+                'dateChanged': Date.now()
+            };
+            trigger.status = status;
+        }
+
+        return new Promise(function(resolve, reject) {
+            utilsDB.nano.insert(trigger, triggerID, function (err) {
+                if (err) {
+                    if (err.statusCode === 409 && retryCount < 5) {
+                        setTimeout(function () {
+                            utilsDB.updateTrigger(triggerID, trigger, params, (retryCount + 1))
+                            .then(id => {
+                                resolve(id);
+                            })
+                            .catch(err => {
+                                reject(err);
+                            });
+                        }, 1000);
+                    }
+                    else {
+                        reject(err.statusCode + 'there was an error while updating the trigger in the database.' + err.message);
+                    }
+                }
+                else {
+                    resolve(triggerID);
+                }
+            });
+        });
+    };
+
+    this.getTriggerByWorkers = function(viewDDName, triggersByWorker, worker) {
+        return new Promise(function(resolve, reject) {
+            utilsDB.nano.view(viewDDName, triggersByWorker, {reduce: false, include_docs: true, key: worker}, function(err, body) {
+                if (err)
+                    reject(err.statusCode + ' could not get latest state from database ');
+                else
+                    resolve(body.rows);
+            });
+        });
+    };
+
+    this.follow = function(config) {
+        return utilsDB.nano.follow(config);
+    };
+};

--- a/provider/lib/database.js
+++ b/provider/lib/database.js
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = function() {
+
+    var database = this;
+
+    // init for DB object - a thin, promise-loving wrapper around nano / documentdb
+    this.initDB = function(config) {
+
+        config.type = typeof config.type  !== 'undefined' ?  config.type  : "couchdb";
+        var db = {};
+        return new Promise((resolve, reject) => {
+
+            if(config.type === "couchdb") {
+                console.log("using couchdb");
+                var couchdb = require('./couchdb');
+                var dbURL = config.protocol + '://' + config.username + ':' + config.password + '@' + config.host;
+                db = new couchdb(dbURL);
+                database.utilsDB = db;
+                resolve();
+            }
+            else if(config.type === "cosmosdb") {
+                console.log("using cosmosdb");
+                var cosmosdb = require('./cosmosdb');
+                db = new cosmosdb(config.host, config.masterkey);
+                db.init(config.rootdb)
+                .then((res) => {
+                    database.utilsDB = db;
+                    resolve();
+                });
+            }
+            else
+                reject("type must be couchdb or cosmosdb; found " + config.type);
+        });
+    };
+
+    this.createDatabase = function(logger, dbName) {
+        return database.utilsDB.createDatabase(logger, dbName);
+    };
+};

--- a/provider/lib/utils.js
+++ b/provider/lib/utils.js
@@ -323,7 +323,7 @@ module.exports = function(logger, triggerDB, redisClient) {
                                 logger.error(method, 'trigger', triggerIdentifier, 'has been disabled due to status code:', response.statusCode);
                             }
                             else {
-                                logger.info(method, 'will create trigger')
+                                logger.info(method, 'will create trigger');
                                 createTrigger(triggerIdentifier, doc)
                                 .then(cachedTrigger => {
                                     self.triggers[triggerIdentifier] = cachedTrigger;
@@ -350,7 +350,7 @@ module.exports = function(logger, triggerDB, redisClient) {
                 logger.error(method, 'could not get latest state from database', err);
             });
     };
-    
+
     function setupFollow(seq) {
         var method = 'setupFollow';
 


### PR DESCRIPTION
_**NOTE:**_ The intention is that this will replace the previous PR #163 going forward.

Changes:
Added support for alarms package to use cosmos DB.
All database interactions will now go through database.js which in turn will delegate to actual DB implementations (`couchdb` or `cosmosdb`) based on `dbType`.