### PR TITLE
Bump action node version to 10

### DIFF
--- a/installCatalog.sh
+++ b/installCatalog.sh
@@ -40,7 +40,7 @@ DB_NAME="${4}alarmservice"
 APIHOST="$5"
 WORKERS="$6"
 LIMIT_CRON_FIELDS="${LIMIT_CRON_FIELDS}"
-ACTION_RUNTIME_VERSION=${ACTION_RUNTIME_VERSION:="nodejs:6"}
+ACTION_RUNTIME_VERSION=${ACTION_RUNTIME_VERSION:="nodejs:10"}
 
 # If the auth key file exists, read the key in the file. Otherwise, take the
 # first argument as the key itself.


### PR DESCRIPTION
As the node runtime `nodejs:6` of upstream is [deprecated](https://github.com/apache/openwhisk/blob/master/ansible/files/runtimes.json#L25), the default node version is raised to `nodejs:10`.
