### PR TITLE
Fixed strict option not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ January 1, 2019, 00:00:00 UTC and will stop firing January 31, 2019, 23:59:00 UT
 
   - If it's true, the Trigger will fire at the top of the hour/minute (\**:**:00).
   - Otherwise, the Trigger will fire after the specific seconds (\**:**:00-59).
+  - If you do not set this value, it is set to the default chosen by the operator.
 
 The delay is determined by the hash value of the Trigger's name, so it keeps the same interval before and after the (re)deployment.
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ January 1, 2019, 00:00:00 UTC and will stop firing January 31, 2019, 23:59:00 UT
   - If it's true, the Trigger will fire at the top of the hour/minute (\**:**:00).
   - Otherwise, the Trigger will fire after the specific seconds (\**:**:00-59).
   - If you do not set this value, it is set to the default chosen by the operator.
+  - Optionally, string values, `"true"` and `"false"` are also recognized as boolean values.
 
 The delay is determined by the hash value of the Trigger's name, so it keeps the same interval before and after the (re)deployment.
 

--- a/action/alarmWebAction.js
+++ b/action/alarmWebAction.js
@@ -103,7 +103,7 @@ function main(params) {
                     }
                     newTrigger.cron = params.cron;
                     newTrigger.timezone = params.timezone;
-                    newTrigger.strict = params.strict === 'true';
+                    newTrigger.strict = params.strict;
                 } catch(ex) {
                     var message = ex.message !== 'Invalid timezone.' ? `cron pattern '${params.cron}' is not valid` : ex.message;
                     return common.sendError(400, message);

--- a/provider/lib/cronAlarm.js
+++ b/provider/lib/cronAlarm.js
@@ -104,7 +104,7 @@ module.exports = function(logger, newTrigger) {
         var method = "distributeCronAlarm";
 
         var cronFields = (trigger.cron + '').trim().split(/\s+/);
-        if (trigger.strict !== 'true' && cronFields.length === 5 && delayLimit !== 0) {
+        if (!trigger.strict && cronFields.length === 5 && delayLimit !== 0) {
             var newCron = [hashName(trigger.name), ...cronFields].join(' ');
             logger.info(method, trigger.triggerID, 'is converted to', '"' + newCron + '"');
             return newCron;


### PR DESCRIPTION
#207 

If you pass a boolean value as the parameter of alarmWebAction, it is passed as a boolean in the main function(even if you use wsk cli). But, since strict parameter is compared with string type, `strict = false` will work no matter what value is passed as parameter.