### PR TITLE
Fix default strict value is always true

### DIFF
--- a/provider/lib/cronAlarm.js
+++ b/provider/lib/cronAlarm.js
@@ -23,7 +23,7 @@ module.exports = function(logger, newTrigger) {
 
     var maxTriggers = newTrigger.maxTriggers || constants.DEFAULT_MAX_TRIGGERS;
     var delayLimit = validateLimit(parseInt(process.env.ALARM_DELAY_LIMIT)) || 0;
-    var delayDefaultStrict = process.env.ALARM_DELAY_DEFAULT_STRICT || false;
+    var delayDefaultStrict = process.env.ALARM_DELAY_DEFAULT_STRICT === "true";
 
     var cachedTrigger = {
         apikey: newTrigger.apikey,


### PR DESCRIPTION
Node process.env is always string. So it need to cast to boolean. 
Currently, there is a problem that `delayDefaultStrict` is always true because env value is either true or false string type.