### PR TITLE
Fix strict default value to false

### DIFF
--- a/action/alarmWebAction.js
+++ b/action/alarmWebAction.js
@@ -191,7 +191,7 @@ function main(params) {
                         reason: doc.status.reason
                     }
                 };
-                var strict = true; // strict is default to true
+                var strict = false; // strict is default to false
                 if (doc.strict !== undefined) {
                     strict = doc.strict;
                 }


### PR DESCRIPTION
- [x] Fix strict's default value to `false`

  After created trigger with sepcify `strick: true or false`, then, used `wsk trigger get ${triggerName}`, can get the strick correctly, and i also created relative rules, actions, after checked, the strick feature worked well, included
  - strick: true,  the trigger's executed time is not floating
  - strick: false,  the trigger's executed time has floating. (e.g. + [0, delayLimit] second)

 But when created trigger without sepcify `strick: true or false`, then used `wsk trigger get ${trigger}`, from result, the strick value is `true`, but i created relative rule, action as well, found that, the trigger's execute time has floating, so the default value should be changed to `false`