### PR TITLE
Make get the strict value correctly when using wsk trigger to get

### DIFF
--- a/action/alarmWebAction.js
+++ b/action/alarmWebAction.js
@@ -191,7 +191,7 @@ function main(params) {
                         reason: doc.status.reason
                     }
                 };
-                var strict = true; // strict is default to true
+                var strict = process.env.ALARM_DELAY_DEFAULT_STRICT === "true";
                 if (doc.strict !== undefined) {
                     strict = doc.strict;
                 }


### PR DESCRIPTION
`the strick value using wsk trigger to get` doesn't keep consistent for its actual execution time, currently, `the stick value using wsk trigget to get` is hardcoded here: https://github.com/apache/openwhisk-package-alarms/blob/master/action/alarmWebAction.js#L194

So here, if want to make it correctly, need to change it to the deployment value(process.env.ALARM_DELAY_DEFAULT_STRICT) as well.