### PR TITLE
Handle URL params gently

### DIFF
--- a/action/alarm.js
+++ b/action/alarm.js
@@ -17,6 +17,13 @@
 
 const common = require('./lib/common');
 
+function addHTTPS(url) {
+    if (!/^(?:f|ht)tps?\:\/\//.test(url)) {
+        url = "https://" + url;
+    }
+    return url;
+}
+
 function main(msg) {
 
     let eventMap = {
@@ -33,8 +40,9 @@ function main(msg) {
 
     var endpoint = msg.apihost;
     var webparams = common.createWebParams(msg);
+    var massagedAPIHost = addHTTPS(endpoint)
 
-    var url = `https://${endpoint}/api/v1/web/whisk.system/alarmsWeb/alarmWebAction.http`;
+    var url = `${massagedAPIHost}/api/v1/web/whisk.system/alarmsWeb/alarmWebAction.http`;
 
     if (lifecycleEvent in eventMap) {
         var method = eventMap[lifecycleEvent];

--- a/action/alarm.js
+++ b/action/alarm.js
@@ -42,7 +42,7 @@ function main(msg) {
     var webparams = common.createWebParams(msg);
     var apiHost = addHTTPS(endpoint);
 
-    var url = `${apiHost}/api/v1/web/whisk.system/alarmsWeb/alarmWebAction.http`;
+    var url = `${apiHost}/api/v1/web/whisk.system/alarmsWeb/alarmWebAction`;
 
     if (lifecycleEvent in eventMap) {
         var method = eventMap[lifecycleEvent];

--- a/action/alarm.js
+++ b/action/alarm.js
@@ -40,7 +40,7 @@ function main(msg) {
 
     var endpoint = msg.apihost;
     var webparams = common.createWebParams(msg);
-    var massagedAPIHost = addHTTPS(endpoint)
+    var massagedAPIHost = addHTTPS(endpoint);
 
     var url = `${massagedAPIHost}/api/v1/web/whisk.system/alarmsWeb/alarmWebAction.http`;
 

--- a/action/alarm.js
+++ b/action/alarm.js
@@ -18,7 +18,7 @@
 const common = require('./lib/common');
 
 function addHTTPS(url) {
-    if (!/^(?:f|ht)tps?\:\/\//.test(url)) {
+    if (!/^https?\:\/\//.test(url)) {
         url = "https://" + url;
     }
     return url;
@@ -40,9 +40,9 @@ function main(msg) {
 
     var endpoint = msg.apihost;
     var webparams = common.createWebParams(msg);
-    var massagedAPIHost = addHTTPS(endpoint);
+    var apiHost = addHTTPS(endpoint);
 
-    var url = `${massagedAPIHost}/api/v1/web/whisk.system/alarmsWeb/alarmWebAction.http`;
+    var url = `${apiHost}/api/v1/web/whisk.system/alarmsWeb/alarmWebAction.http`;
 
     if (lifecycleEvent in eventMap) {
         var method = eventMap[lifecycleEvent];


### PR DESCRIPTION
Previously url variable has strictly provided "https" protocol,
which totally broke feed if "https" was provided in endpoint variable.
Add new function based on regex to handle both types with or
without protocol.