### PR TITLE
Bump up cron to 1.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "repository": "github:apache/openwhisk-package-alarms",
   "dependencies": {
     "body-parser": "^1.15.0",
-    "cron": "1.7.0",
+    "cron": "1.8.2",
     "express": "^4.13.4",
     "lodash": "^4.5.0",
     "nano": "6.4.4",


### PR DESCRIPTION
## Description
The cron expression `5/10 * * * *` doesn't work in the alarm package using the cron library version 1.7.0. 
I expect it to run at 5, 15, 25, 35, 45, and 55 minutes every hour, but it only runs once at 5 minutes.

This can be solved by upgrading the latest version of the cron library.

- cron@ 1.7.0 (current version)
- cron@ 1.8.2 (latest)

### Sample code
```javascript
var CronJob = require('cron').CronJob;
var job = new CronJob('0 5/10 * * * *', function() {
  console.log('You will see this message every second', new Date());
}, null, true, 'America/Los_Angeles');
job.start();
```

And also I've confirmed that the alarms package using the latest cron library works well in our cluster.